### PR TITLE
[Week-1]  Support delete operation for generic slice

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/go-basics.iml
+++ b/.idea/go-basics.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/go-basics.iml" filepath="$PROJECT_DIR$/.idea/go-basics.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/syntax/generics/slice/slice.go
+++ b/syntax/generics/slice/slice.go
@@ -1,7 +1,5 @@
 package slice
 
-import "fmt"
-
 type ISlice[T comparable] interface {
 	Append(val T)
 	// Delete removes the elements slice[i:j]
@@ -39,21 +37,18 @@ func (s *Slice[T]) Append(val T) {
 
 func (s *Slice[T]) Delete(idxFrom int, idxTo int) {
 	_ = s.data[idxFrom:idxTo]
-	fmt.Println("cap before", cap(s.data))
 
 	m := len(s.data)
 	n := m - (idxTo - idxFrom + 1)
-	fmt.Println("m", m, "n", n, "cap", cap(s.data))
 	if 2*n < cap(s.data) {
-		s2 := make([]T, cap(s.data)/2)
+		s2 := make([]T, n, cap(s.data)/2)
 		copy(s2, s.data[:idxFrom])
 		copy(s2[idxFrom:], s.data[idxTo+1:])
 		s.data = s2
-		fmt.Println("cap after", cap(s.data))
-
+		return
 	}
 	s.data = append(s.data[:idxFrom], s.data[idxTo+1:]...)
-	fmt.Println("cap after, should no change", cap(s.data))
+	//fmt.Println("cap after, should no change", cap(s.data))
 
 }
 

--- a/syntax/generics/slice/slice.go
+++ b/syntax/generics/slice/slice.go
@@ -1,0 +1,62 @@
+package slice
+
+import "fmt"
+
+type ISlice[T comparable] interface {
+	Append(val T)
+	// Delete removes the elements slice[i:j]
+	Delete(idxFrom int, idxTo int)
+	Get(idx int) T
+}
+
+type Slice[T comparable] struct {
+	data []T
+}
+
+func NewSlice[T comparable](vals ...T) *Slice[T] {
+	s := Slice[T]{}
+	s.data = make([]T, len(vals))
+	for i, v := range vals {
+		s.data[i] = v
+	}
+	return &s
+}
+
+func (s *Slice[T]) Get(idx int) T {
+	if idx >= s.Len() {
+		panic("index exceeds the length of slice")
+	}
+	return s.data[idx]
+}
+
+func (s *Slice[T]) Len() int {
+	return len(s.data)
+}
+
+func (s *Slice[T]) Append(val T) {
+	s.data = append(s.data, val)
+}
+
+func (s *Slice[T]) Delete(idxFrom int, idxTo int) {
+	_ = s.data[idxFrom:idxTo]
+	fmt.Println("cap before", cap(s.data))
+
+	m := len(s.data)
+	n := m - (idxTo - idxFrom + 1)
+	fmt.Println("m", m, "n", n, "cap", cap(s.data))
+	if 2*n < cap(s.data) {
+		s2 := make([]T, cap(s.data)/2)
+		copy(s2, s.data[:idxFrom])
+		copy(s2[idxFrom:], s.data[idxTo+1:])
+		s.data = s2
+		fmt.Println("cap after", cap(s.data))
+
+	}
+	s.data = append(s.data[:idxFrom], s.data[idxTo+1:]...)
+	fmt.Println("cap after, should no change", cap(s.data))
+
+}
+
+func (s *Slice[T]) Cap() int {
+	return cap(s.data)
+}

--- a/syntax/generics/slice/slice_test.go
+++ b/syntax/generics/slice/slice_test.go
@@ -1,0 +1,98 @@
+package slice
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Slice_Delete(t *testing.T) {
+	testCases := []struct {
+		name          string
+		s             *Slice[int]
+		expectedSlice *Slice[int]
+		expectedCap   int
+		deletedIdx    []int
+	}{
+		{
+			name:          "delete the first element",
+			s:             NewSlice[int](1, 2, 3),
+			expectedSlice: NewSlice[int](2, 3),
+			expectedCap:   3,
+			deletedIdx:    []int{0, 0},
+		},
+		{
+			name:          "delete the last element",
+			s:             NewSlice[int](1, 2, 3),
+			expectedSlice: NewSlice[int](1, 2),
+			expectedCap:   3,
+			deletedIdx:    []int{2, 2},
+		},
+		{
+			name:          "delete the middle element",
+			s:             NewSlice[int](1, 2, 3),
+			expectedSlice: NewSlice[int](1, 3),
+			expectedCap:   3,
+			deletedIdx:    []int{1, 1},
+		},
+		{
+			name:          "delete the last two element",
+			s:             NewSlice[int](1, 2, 3),
+			expectedSlice: NewSlice[int](1),
+			expectedCap:   1,
+			deletedIdx:    []int{1, 2},
+		},
+		{
+			name:          "reduce the capacity by half",
+			s:             NewSlice[int](1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8),
+			expectedSlice: NewSlice[int](1, 2),
+			expectedCap:   16,
+			deletedIdx:    []int{2, 31},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.s.Delete(tc.deletedIdx[0], tc.deletedIdx[1])
+			assert.Equal(t, tc.expectedSlice, tc.s)
+			assert.Equal(t, tc.expectedCap, tc.s.Cap())
+		})
+	}
+}
+
+func Test_Slice_Append(t *testing.T) {
+	a := NewSlice[int]()
+	a.Append(1)
+	b := NewSlice[int](1, 2, 3)
+	isEqual, msg := Equal(a, b)
+	assert.Equal(t, isEqual, false)
+	assert.Equal(t, msg, "the length of slice is different")
+
+	a = NewSlice[int]()
+	a.Append(1)
+	a.Append(3)
+	a.Append(3)
+	fmt.Printf("%+v\n", a)
+	b = NewSlice[int](1, 2, 3)
+	isEqual, msg = Equal(a, b)
+	assert.Equal(t, isEqual, false)
+	assert.Equal(t, msg, "index: 1, value: 3 and value: 2 does not match")
+
+	a = NewSlice[int](1, 2, 3)
+	b = NewSlice[int](1, 2, 3)
+	isEqual, msg = Equal(a, b)
+	assert.Equal(t, isEqual, true)
+}
+
+func Equal[T comparable](a *Slice[T], b *Slice[T]) (bool, string) {
+	if a.Len() != b.Len() {
+		return false, "the length of slice is different"
+	}
+
+	for i := 0; i < a.Len(); i++ {
+		if a.data[i] != b.data[i] {
+			return false, fmt.Sprintf("index: %d, value: %+v and value: %+v does not match", i, a.Get(i), b.Get(i))
+		}
+	}
+	return true, ""
+}

--- a/syntax/generics/slice/slice_test.go
+++ b/syntax/generics/slice/slice_test.go
@@ -72,7 +72,6 @@ func Test_Slice_Append(t *testing.T) {
 	a.Append(1)
 	a.Append(3)
 	a.Append(3)
-	fmt.Printf("%+v\n", a)
 	b = NewSlice[int](1, 2, 3)
 	isEqual, msg = Equal(a, b)
 	assert.Equal(t, isEqual, false)


### PR DESCRIPTION
实现切片的删除操作 实现删除切片特定下标元素的方法。
• 要求一:能够实现删除操作就可以。
• 要求二:考虑使用比较高性能的实现。
• 要求三:改造为泛型方法。
• 要求四:支持缩容，并且设计缩容机制。